### PR TITLE
fix description meta tag typo

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -36,7 +36,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
           <Head>
             <title>노래책</title>
             <meta
-              name='desciption'
+              name='description'
               content='당신만의 온라인, 오프라인 버스킹을 여기서 시작하세요. 
                     당신만의 노래 리스트를 생성하여 애창곡을 검색하여 저장하세요.
                     버스킹을 시작하여 공유되는 링크를 이용하여 관객들로부터 노래를


### PR DESCRIPTION
## Summary
- correct name attribute from `desciption` to `description` in `_app.tsx`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450fd753a88326bfe20411d7fb03e0